### PR TITLE
move from dockerhub to ECR for base images

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.7-slim
+FROM public.ecr.aws/docker/library/python:3.10.7-slim
 
 ARG BUILD_ENV
 ENV BUILD_ENV=${BUILD_ENV}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.19.1-buster-slim
+FROM public.ecr.aws/docker/library/node:18.19.1-buster-slim
 
 WORKDIR /usr/src/frontend
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM public.ecr.aws/nginx/nginx:stable-perl
 
 COPY ./nginx.conf.template /etc/nginx/templates/nginx.conf.template
 COPY ./docker/entrypoint.sh /


### PR DESCRIPTION
DockerHub has rate limits that were causing our builds to fail.